### PR TITLE
#125: Documentation review - add CLI quick start and fix import

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,52 @@ folder: ./migrations
 logLevel: debug  # error | warn | info | debug
 ```
 
+### CLI Usage (v0.7.0)
+
+**Create a CLI for your database adapter:**
+
+```typescript
+// cli.ts
+import { createCLI, MigrationScriptExecutor } from '@migration-script-runner/core';
+import { MyDatabaseHandler } from './database-handler';
+
+const program = createCLI({
+  name: 'my-db-migrate',
+  version: '1.0.0',
+  description: 'Database migration CLI',
+  createExecutor: (config) => {
+    const handler = new MyDatabaseHandler();
+    return new MigrationScriptExecutor({ handler, config });
+  }
+});
+
+program.parse(process.argv);
+```
+
+**Run migrations from command line:**
+
+```bash
+# Run all pending migrations
+npx my-db-migrate migrate
+
+# List all migrations with status
+npx my-db-migrate list
+
+# Rollback last migration
+npx my-db-migrate down
+
+# Validate migrations without running
+npx my-db-migrate validate
+
+# Create database backup
+npx my-db-migrate backup
+
+# Use environment-specific config
+npx my-db-migrate migrate --config-file .env.production
+```
+
+**[→ Full CLI Documentation](https://migration-script-runner.github.io/msr-core/guides/cli-adapter-development)**
+
 ---
 
 ## 📚 Documentation

--- a/docs/index.md
+++ b/docs/index.md
@@ -114,9 +114,10 @@ A database-agnostic migration framework for TypeScript and JavaScript projects.
 
 ## What's New in v0.7.0
 
-🎉 Latest release brings CLI factory and improved architecture:
+🎉 Latest release brings CLI factory, .env file support, and improved architecture:
 
 - **🖥️ CLI Factory** - Create command-line interfaces with built-in commands (migrate, list, down, validate, backup) using Commander.js - see [CLI Adapter Development Guide](guides/cli-adapter-development)
+- **🗂️ .env File Support** - Load configuration from .env, .env.production, .env.local files with configurable priority
 - **🎨 Facade Pattern** - Services grouped into logical facades (core, execution, output, orchestration) for better code organization
 - **🏭 Factory Pattern** - Dedicated service initialization reduces constructor complexity by 83%
 - **🔧 Protected Facades** - Adapters can extend MigrationScriptExecutor and access internal services through protected facades


### PR DESCRIPTION
Added CLI usage section to README with createCLI example and commands. Updated docs/index.md to include .env file support in What's New. Fixed missing MigrationScriptExecutor import in CLI example.